### PR TITLE
Improve the Russian translation

### DIFF
--- a/Resources/Language.json
+++ b/Resources/Language.json
@@ -129,18 +129,18 @@
   },
   "RU": {
     "Map Zones": {
-      "GODHOME": "Дом богов",
+      "GODHOME": "Божий кров",
       "PathOfPainArea": "Путь боли",
-      "WorkshopArea": "цех",
+      "WorkshopArea": "Мастерская",
       "CreditsArea": "Карта от @molamolasses",
       "PantheonArea": "Пантеоны",
-      "PohArea": "Пантеон Hallownest"
+      "PohArea": "Пантеон Халлоунеста"
     },
     "UI": {
       "MAP_NAME_WHITE_PALACE": "Белый дворец",
-      "MAP_NAME_GODHOME": "Дом богов",
+      "MAP_NAME_GODHOME": "Божий кров",
       "SFGrenadeAdditionalMaps_WpMapName": "Карта Белого дворца",
-      "SFGrenadeAdditionalMaps_GhMapName": "Карта Дома богов "
+      "SFGrenadeAdditionalMaps_GhMapName": "Карта Божьего крова"
     }
   },
   "ZH": {


### PR DESCRIPTION
Add an official translation. (can be checked on the Fandom, on the Russian sub-website)

Change:

- `Дом богов` to `Божий кров`: https://hollowknight.fandom.com/ru/wiki/Божий_кров (the accusative case in the map name can look a bit strange, but it's correct)
- `Цех` to `Мастерская`: https://hollowknight.fandom.com/ru/wiki/Белый_дворец#Описание (the first item of the bulleted list at the end of the section)
- `Пантеон Hallownest` to `Пантеон Халлоунеста`: https://hollowknight.fandom.com/ru/wiki/Пантеон_Халлоунеста